### PR TITLE
refs #81419 execute `composer require protonlabs/paypal-sdk-core-php:dev-master`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "protonlabs/paypal-sdk-core-php": "dev-master"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
For https://github.com/tyrellsys/hobbystock-ec/pull/196

Fix to mistake in PR #1.
There was a lack of execute `composer require protonlabs/paypal-sdk-core-php:dev-master`.